### PR TITLE
Change :latest to not hit rubygems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,37 @@ AllCops:
   Excludes:
     - vendor/**
     - bin/**
+ClassLength:
+  Enabled: false
+CommentAnnotation:
+  Enabled: false
+Documentation:
+  Enabled: false
+DoubleNegation:
+  Enabled: false
 Encoding:
   Enabled: false
-ClassLength:
+FormatString:
+  Enabled: false
+IfUnlessModifier:
+  Enabled: false
+LineLength:
   Enabled: false
 MethodLength:
   Enabled: false
+PercentLiteralDelimiters:
+  Enabled: false
+RedundantReturn:
+  Enabled: false
+SignalException:
+  Enabled: false
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+SpaceInsideBrackets:
+  Enabled: false
+SpaceInsideParens:
+  Enabled: false
+StringLiterals:
+  Enabled: false
+TrailingComma:
+  EnforcedStyleForMultiline: comma

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ namespace :style do
       '**/Vagrantfile',
       '*.gemspec',
       'Gemfile',
-      'Rakefile'
+      'Rakefile',
     ]
   end
 end

--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -47,13 +47,13 @@ module VagrantPlugins
             if installed_version == desired_version
               env[:ui].info I18n.t(
                 'vagrant-omnibus.action.installed',
-                version: desired_version
+                version: desired_version,
               )
             else
               fetch_or_create_install_script(env)
               env[:ui].info I18n.t(
                 'vagrant-omnibus.action.installing',
-                version: desired_version
+                version: desired_version,
               )
               install(desired_version, env)
               recover(env)
@@ -224,7 +224,7 @@ module VagrantPlugins
               downloader = Vagrant::Util::Downloader.new(
                 url,
                 @script_tmp_path,
-                {}
+                {},
               )
               downloader.download!
             end

--- a/lib/vagrant-omnibus/config.rb
+++ b/lib/vagrant-omnibus/config.rb
@@ -39,9 +39,6 @@ module VagrantPlugins
       def finalize!
         if @chef_version == UNSET_VALUE
           @chef_version = nil
-        elsif @chef_version.to_s == 'latest'
-          # resolve `latest` to a real version
-          @chef_version = retrieve_latest_chef_version
         end
         # enable caching by default
         @cache_packages = true if @cache_packages == UNSET_VALUE
@@ -80,40 +77,19 @@ A list of valid versions can be found at: http://www.opscode.com/chef/install/
 
       private
 
-      # Query RubyGems.org's Ruby API and retrive the latest version of Chef.
-      def retrieve_latest_chef_version
-        available_gems =
-          dependency_installer.find_gems_with_sources(chef_gem_dependency)
-        spec, _source =
-        if available_gems.respond_to?(:last)
-          # DependencyInstaller sorts the results such that the last one is
-          # always the one it considers best.
-          spec_with_source = available_gems.last
-          spec_with_source
-        else
-          # Rubygems 2.0 returns a Gem::Available set, which is a
-          # collection of AvailableSet::Tuple structs
-          available_gems.pick_best!
-          best_gem = available_gems.set.first
-          best_gem && [best_gem.spec, best_gem.source]
-        end
-
-        spec && spec.version.to_s
-      end
-
       # Query RubyGems.org's Ruby API to see if the user-provided Chef version
       # is in fact a real Chef version!
       def valid_chef_version?(version)
-        is_valid = false
+        return true if version.to_s == "latest"
         begin
           available = dependency_installer.find_gems_with_sources(
             chef_gem_dependency(version)
           )
-          is_valid = true unless available.empty?
         rescue ArgumentError => e
           @logger.debug("#{version} is not a valid Chef version: #{e}")
+          return false
         end
-        is_valid
+        return !available.empty?
       end
 
       def dependency_installer

--- a/lib/vagrant-omnibus/config.rb
+++ b/lib/vagrant-omnibus/config.rb
@@ -69,7 +69,7 @@ A list of valid versions can be found at: http://www.opscode.com/chef/install/
         if errors.any?
           rendered_errors = Vagrant::Util::TemplateRenderer.render(
                               'config/validation_failed',
-                              errors: { 'vagrant-omnibus' => errors }
+                              errors: { 'vagrant-omnibus' => errors },
                             )
           fail Vagrant::Errors::ConfigInvalid, errors: rendered_errors
         end
@@ -83,7 +83,7 @@ A list of valid versions can be found at: http://www.opscode.com/chef/install/
         return true if version.to_s == "latest"
         begin
           available = dependency_installer.find_gems_with_sources(
-            chef_gem_dependency(version)
+            chef_gem_dependency(version),
           )
         rescue ArgumentError => e
           @logger.debug("#{version} is not a valid Chef version: #{e}")

--- a/lib/vagrant-omnibus/plugin.rb
+++ b/lib/vagrant-omnibus/plugin.rb
@@ -33,7 +33,8 @@ module VagrantPlugins
       # @return [Boolean]
       def self.check_vagrant_version(*requirements)
         Gem::Requirement.new(*requirements).satisfied_by?(
-          Gem::Version.new(Vagrant::VERSION))
+          Gem::Version.new(Vagrant::VERSION),
+        )
       end
 
       # Verifies that the Vagrant version fulfills the requirements
@@ -44,8 +45,9 @@ module VagrantPlugins
         unless check_vagrant_version(VAGRANT_VERSION_REQUIREMENT)
           msg = I18n.t(
             'vagrant-omnibus.errors.vagrant_version',
-            requirement: VAGRANT_VERSION_REQUIREMENT.inspect)
-          $stderr.puts msg
+            requirement: VAGRANT_VERSION_REQUIREMENT.inspect,
+          )
+          $stderr.puts(msg)
           fail msg
         end
       end
@@ -60,8 +62,10 @@ module VagrantPlugins
         # mitchellh/vagrant-aws/blob/v0.3.0/lib/vagrant-aws/action.rb#L105
         #
         if defined? VagrantPlugins::AWS::Action::TimedProvision
-          hook.after(VagrantPlugins::AWS::Action::TimedProvision,
-                     Action::InstallChef)
+          hook.after(
+            VagrantPlugins::AWS::Action::TimedProvision,
+            Action::InstallChef,
+          )
         end
       end
 

--- a/test/unit/vagrant-omnibus/config_spec.rb
+++ b/test/unit/vagrant-omnibus/config_spec.rb
@@ -27,10 +27,9 @@ describe VagrantPlugins::Omnibus::Config do
     its(:cache_packages) { should be_true }
   end
 
-  describe 'resolving `:latest` to a real Chef version' do
+  describe 'should no longer resolve :latest to a Chef version' do
     let(:chef_version) { :latest }
-    its(:chef_version) { should be_a(String) }
-    its(:chef_version) { should match(/\d*\.\d*\.\d*/) }
+    its(:chef_version) { should eql(:latest) }
   end
 
   describe 'setting a custom `install_url`' do

--- a/test/unit/vagrant-omnibus/config_spec.rb
+++ b/test/unit/vagrant-omnibus/config_spec.rb
@@ -64,16 +64,16 @@ describe VagrantPlugins::Omnibus::Config do
       {
         '11.4.0' => {
           description: 'valid Chef version string',
-          valid: true
+          valid: true,
         },
         '10.99.99' => {
           description: 'invalid Chef version string',
-          valid: false
+          valid: false,
         },
         'FUFUFU' => {
           description: 'invalid RubyGems version string',
-          valid: false
-        }
+          valid: false,
+        },
       }.each_pair do |version_string, opts|
         context "#{opts[:description]}: #{version_string}" do
           let(:chef_version) { version_string }

--- a/test/unit/vagrant-omnibus/plugin_spec.rb
+++ b/test/unit/vagrant-omnibus/plugin_spec.rb
@@ -50,7 +50,8 @@ describe VagrantPlugins::Omnibus::Plugin do
     before :each do
       stub_const(
         'VagrantPlugins::ProxyConf::Plugin::VAGRANT_VERSION_REQUIREMENT',
-        requirement)
+        requirement,
+      )
       stub_const('Vagrant::VERSION', vagrant_version)
       $stderr.stub(:puts)
     end


### PR DESCRIPTION
Just send the string "latest" into the omnibus API.  This makes it
not idempotent so that it will run install.sh every time.  Since we
hit rubygems before we're no better off in disconnected mode that
we were before.

Tested on Ubuntu and CentOS, the acceptance tests for windows are
trolling me hard and I don't know how to fix.