### PR TITLE
Quote the path to the MSI given to msiexec

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -216,7 +216,7 @@ module VagrantPlugins
                   echo Downloading Chef %version% for Windows...
                   powershell -command "(New-Object System.Net.WebClient).DownloadFile('#{url}?v=%version%', '%dest%')"
                   echo Installing Chef %version%
-                  msiexec /q /i %dest%
+                  msiexec /q /i "%dest%"
                 EOH
               end
               # rubocop:enable LineLength, SpaceAroundBlockBraces


### PR DESCRIPTION
This way, spaces in the path will be correctly handled.

Without the quotes, msiexec hangs (presenting a GUI usage statement) if there are spaces in the path.
