### PR TITLE
Fix msiexec option.

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -216,7 +216,7 @@ module VagrantPlugins
                   echo Downloading Chef %version% for Windows...
                   powershell -command "(New-Object System.Net.WebClient).DownloadFile('#{url}?v=%version%', '%dest%')"
                   echo Installing Chef %version%
-                  msiexec /q /i %dest%
+                  msiexec /qn /i %dest%
                 EOH
               end
               # rubocop:enable LineLength, SpaceAroundBlockBraces


### PR DESCRIPTION
Unable to install chef on modern.ie VM (IE11.Win7.For.Mac).
We mayb need "/qn" option.
https://docs.chef.io/windows.html#microsoft-msiexec
https://msdn.microsoft.com/en-us/library/cc759262%28v=ws.10%29.aspx#BKMK_SetUI
