### PR TITLE
Cast upload file path to string

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -158,7 +158,7 @@ module VagrantPlugins
           shell_escaped_version = Shellwords.escape(version)
 
           @machine.communicate.tap do |comm|
-            comm.upload(@script_tmp_path, install_script_name)
+            comm.upload(@script_tmp_path.to_s, install_script_name)
             if windows_guest?
               install_cmd = "cmd.exe /c #{install_script_name} #{version}"
             else


### PR DESCRIPTION
Fix #130. The winrm-fs gem does not appear to handle Pathname objects correctly.