### PR TITLE
Fix installing chef on windows in vagrant 1.8.3 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 before_install:
   - rvm @global do gem uninstall bundler --all --executables
   - gem uninstall bundler --all --executables
-  - gem install bundler --version '< 1.7.0'
+  - gem install bundler --version '1.12.5'
 
 bundler_args: --jobs 7 --without=acceptance
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.6.4'
-  gem 'vagrant-windows', '~> 1.6.0'
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.8.4'
+  gem 'listen', '~> 3.0.8'
 end
 
 group :acceptance do

--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -116,6 +116,14 @@ module VagrantPlugins
           end
         end
 
+        def install_script_path
+          if windows_guest?
+            "$env:temp/vagrant-omnibus/#{install_script_name}"
+          else
+            "/tmp/vagrant-omnibus/#{install_script_name}"
+          end
+        end
+
         def windows_guest?
           @machine.config.vm.guest.eql?(:windows)
         end
@@ -126,7 +134,7 @@ module VagrantPlugins
 
         def communication_opts
           if windows_guest?
-            { shell: 'cmd' }
+            { shell: 'powershell' }
           else
             { shell: 'sh' }
           end
@@ -135,12 +143,8 @@ module VagrantPlugins
         def installed_version
           version = nil
           opts = communication_opts
-          if windows_guest?
-            command = 'cmd.exe /c chef-solo -v'
-            opts[:error_check] = false
-          else
-            command = 'echo $(chef-solo -v)'
-          end
+          opts[:error_check] = false if windows_guest?
+          command = 'echo $(chef-solo -v)'
           @machine.communicate.sudo(command, opts) do |type, data|
             if [:stderr, :stdout].include?(type)
               version_match = data.match(/^Chef: (.+)/)
@@ -158,11 +162,11 @@ module VagrantPlugins
           shell_escaped_version = Shellwords.escape(version)
 
           @machine.communicate.tap do |comm|
-            comm.upload(@script_tmp_path, install_script_name)
+            comm.upload(@script_tmp_path, install_script_path)
             if windows_guest?
-              install_cmd = "cmd.exe /c #{install_script_name} #{version}"
+              install_cmd = "& #{install_script_path} #{version}"
             else
-              install_cmd = "sh #{install_script_name}"
+              install_cmd = "sh #{install_script_path}"
               install_cmd << " -v #{shell_escaped_version}"
               if download_to_cached_dir?
                 install_cmd << " -d #{cached_omnibus_download_dir}"
@@ -183,8 +187,9 @@ module VagrantPlugins
         # Vagrant TMP directory.
         #
         def fetch_or_create_install_script(env)
-          @script_tmp_path =
-            env[:tmp_path].join("#{Time.now.to_i.to_s}-#{install_script_name}")
+          @script_tmp_path = env[:tmp_path].join(
+            "#{Time.now.to_i.to_s}-#{install_script_name}"
+          ).to_s
 
           @logger.info("Generating install script at: #{@script_tmp_path}")
 

--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -116,12 +116,16 @@ module VagrantPlugins
           end
         end
 
-        def install_script_path
+        def install_script_folder
           if windows_guest?
-            "$env:temp/vagrant-omnibus/#{install_script_name}"
+            '$env:temp/vagrant-omnibus'
           else
-            "/tmp/vagrant-omnibus/#{install_script_name}"
+            '/tmp/vagrant-omnibus'
           end
+        end
+
+        def install_script_path
+          File.join(install_script_folder, install_script_name)
         end
 
         def windows_guest?
@@ -162,7 +166,12 @@ module VagrantPlugins
           shell_escaped_version = Shellwords.escape(version)
 
           @machine.communicate.tap do |comm|
+            unless windows_guest?
+              comm.execute("mkdir -p #{install_script_folder}")
+            end
+
             comm.upload(@script_tmp_path, install_script_path)
+
             if windows_guest?
               install_cmd = "& #{install_script_path} #{version}"
             else

--- a/test/acceptance/virtualbox/Vagrantfile
+++ b/test/acceptance/virtualbox/Vagrantfile
@@ -5,7 +5,6 @@
 
 # plugins don't seem to be auto-loaded from the bundle
 require 'vagrant-omnibus'
-require 'vagrant-windows'
 
 def box_type
   @box_type ||= begin
@@ -64,7 +63,6 @@ Vagrant.configure('2') do |config|
     # build this yourself https://github.com/misheska/basebox-packer
     # win_config.vm.box_url           = ''
     win_config.vm.boot_timeout      = 500
-    win_config.winrm.timeout        = 500
 
     win_config.omnibus.chef_version = :latest
 


### PR DESCRIPTION
Vagrant 1.8.3 uses winrm-fs to copy files from the host to the guest VM. vagrant-omnibus passes the destination of the chef install script to the communicator's upload method with a `Pathname`. However the vagrant `Communicator` interface [expects a `String`](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/plugin/v2/communicator.rb#L81-L85). Prior to vagrant 1.8.3, its implementation was forgiving of `Pathname` but winrm-fs breaks on `Pathname`. [Winrm-fs v2](https://github.com/WinRb/winrm-fs/pull/45) will also be forgiving but we can fix users sooner via this fix.

See https://github.com/WinRb/winrm-fs/issues/47 and https://github.com/mitchellh/vagrant/issues/7459

Further, winrm-fs requires an absolute path for the upload destination. Again, winrm-fs v2 will address that as well, however, its probably best to save the install script to the temp directory so this PR does that for both windows and linux.

I also updated gems to align with vagrant 1.8.4 and provide compatibility with ruby 2.0.