### PR TITLE
Convert specs to rspec 3 format

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---default_path test/unit
+--default-path test/unit

--- a/test/unit/spec_helper.rb
+++ b/test/unit/spec_helper.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
   config.alias_it_should_behave_like_to :it_has_behavior, "has behavior:"
 
   # Use color in STDOUT
-  config.color_enabled = true
+  config.color = true
 
   # Use color not only in STDOUT but also in pagers and files
   config.tty = true
@@ -18,8 +18,6 @@ RSpec.configure do |config|
   # run the examples in random order
   config.order = :rand
 
-  # specify metadata with symobls only (ie no '=> true' required)
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end

--- a/test/unit/vagrant-omnibus/config_spec.rb
+++ b/test/unit/vagrant-omnibus/config_spec.rb
@@ -1,10 +1,4 @@
-# We have to use `require_relative` until RSpec 2.14.0. As non-standard RSpec
-# default paths are not on the $LOAD_PATH.
-#
-# More info here:
-# https://github.com/rspec/rspec-core/pull/831
-#
-require_relative "../spec_helper"
+require "spec_helper"
 
 # rubocop:disable LineLength
 
@@ -21,39 +15,66 @@ describe VagrantPlugins::Omnibus::Config do
     end
   end
 
-  describe "defaults" do
-    its(:chef_version) { should be_nil }
-    its(:install_url) { should be_nil }
-    its(:cache_packages) { should be_true }
+  context "default values" do
+    describe "#chef_version" do
+      subject { super().chef_version }
+      it { is_expected.to be_nil }
+    end
+
+    describe "#install_url" do
+      subject { super().install_url }
+      it { is_expected.to be_nil }
+    end
+
+    describe "#cache_packages" do
+      subject { super().cache_packages }
+      it { is_expected.to be_truthy }
+    end
   end
 
-  describe "should no longer resolve :latest to a Chef version" do
+  describe "no longer resolves :latest to a Chef version" do
     let(:chef_version) { :latest }
-    its(:chef_version) { should eql(:latest) }
+
+    describe "#chef_version" do
+      subject { super().chef_version }
+      it { is_expected.to eql(:latest) }
+    end
   end
 
   describe "setting a custom `install_url`" do
     let(:install_url) { "http://some_path.com/install.sh" }
-    its(:install_url) { should eq("http://some_path.com/install.sh") }
+
+    describe "#install_url" do
+      subject { super().install_url }
+      it { is_expected.to eq("http://some_path.com/install.sh") }
+    end
   end
 
   describe "the `cache_packages` config option behaves truthy" do
     [true, "something", :cachier].each do |obj|
       describe "when `#{obj}` (#{obj.class})" do
         let(:cache_packages) { obj }
-        its(:cache_packages) { should be_true }
+
+        describe "#cache_packages" do
+          subject { super().cache_packages }
+          it { is_expected.to be_truthy }
+        end
       end
     end
     [nil, false].each do |obj|
       describe "when `#{obj}` (#{obj.class})" do
         let(:cache_packages) { obj }
-        its(:cache_packages) { should be_false }
+
+        describe "#cache_packages" do
+          subject { super().cache_packages }
+          it { is_expected.to be_falsey }
+        end
       end
     end
   end
 
   describe "validate" do
-    it "should be no-op" do
+    it "is a be no-op" do
       expect(subject.validate(machine)).to eq("VagrantPlugins::Omnibus::Config" => [])
     end
   end
@@ -91,7 +112,7 @@ describe VagrantPlugins::Omnibus::Config do
 
     describe "not specified chef_version validation" do
       it "passes" do
-        Gem::DependencyInstaller.any_instance.stub(:find_gems_with_sources).and_return([])
+        allow_any_instance_of(Gem::DependencyInstaller).to receive(:find_gems_with_sources).and_return([])
         expect { subject.validate!(machine) }.to_not raise_error
       end
     end # describe not specified chef_version validation

--- a/test/unit/vagrant-omnibus/plugin_spec.rb
+++ b/test/unit/vagrant-omnibus/plugin_spec.rb
@@ -1,5 +1,4 @@
-require_relative "../spec_helper"
-# rubocop:disable LineLength
+require "spec_helper"
 
 describe VagrantPlugins::Omnibus::Plugin do
 
@@ -27,18 +26,18 @@ describe VagrantPlugins::Omnibus::Plugin do
     end
 
     it "accepts single String argument" do
-      expect(described_class.check_vagrant_version("~> 1.1")).to be_true
-      expect(described_class.check_vagrant_version("1.2")).to be_false
+      expect(described_class.check_vagrant_version("~> 1.1")).to be_truthy
+      expect(described_class.check_vagrant_version("1.2")).to be_falsey
     end
 
     it "accepts an Array argument" do
-      expect(described_class.check_vagrant_version([">= 1.1", "< 1.3.0.beta"])).to be_true
-      expect(described_class.check_vagrant_version([">= 1.3"])).to be_false
+      expect(described_class.check_vagrant_version([">= 1.1", "< 1.3.0.beta"])).to be_truthy
+      expect(described_class.check_vagrant_version([">= 1.3"])).to be_falsey
     end
 
     it "accepts multiple arguments" do
-      expect(described_class.check_vagrant_version(">= 1.0", "<= 1.3")).to be_true
-      expect(described_class.check_vagrant_version("~> 1.2", ">= 1.2.5")).to be_false
+      expect(described_class.check_vagrant_version(">= 1.0", "<= 1.3")).to be_truthy
+      expect(described_class.check_vagrant_version("~> 1.2", ">= 1.2.5")).to be_falsey
     end
   end
 
@@ -53,7 +52,7 @@ describe VagrantPlugins::Omnibus::Plugin do
         requirement
       )
       stub_const("Vagrant::VERSION", vagrant_version)
-      $stderr.stub(:puts)
+      allow($stderr).to receive(:puts)
     end
 
     context "on too old Vagrant version" do
@@ -62,7 +61,7 @@ describe VagrantPlugins::Omnibus::Plugin do
         expect { subject }.to raise_error(err_msg)
       end
       it "warns as stderr" do
-        $stderr.should_receive(:puts).with(err_msg)
+        expect($stderr).to receive(:puts).with(err_msg)
         expect { subject }.to raise_error(err_msg)
       end
     end

--- a/vagrant-omnibus.gemspec
+++ b/vagrant-omnibus.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 11.0"
-  spec.add_development_dependency "rspec", "~> 2.99.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "chefstyle", "~> 0.4.0"
 end


### PR DESCRIPTION
This was mostly done with transpec and some of its decisions seem a bit odd although I'm about as far from an rspec expert as it gets. Let me know if this makes sense or not. On the plus side this gets us to rspec 3 without deprecation warnings now.

Signed-off-by: Tim Smith <tsmith@chef.io>