### PR TITLE
Add github_changelog_generator and release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,195 +1,98 @@
-# vagrant-omnibus Changelog
+# Change Log
 
-This file is used to list changes made in each version of the vagrant-omnibus plugin.
+## [1.5.0](https://github.com/chef/vagrant-omnibus/tree/1.5.0) (2016-08-31)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.4.1...1.5.0)
 
-## 1.4.1 (April 26, 2014)
+**Merged pull requests:**
 
-### Bug Fixes
+- Convert specs to rspec 3 format [\#138](https://github.com/chef/vagrant-omnibus/pull/138) ([tas50](https://github.com/tas50))
+- Testing improvements, dep bumps, and fixes [\#137](https://github.com/chef/vagrant-omnibus/pull/137) ([tas50](https://github.com/tas50))
+- Fix installing chef on windows in vagrant 1.8.3 and up [\#135](https://github.com/chef/vagrant-omnibus/pull/135) ([mwrock](https://github.com/mwrock))
+- Fixed Travis CI image and link. [\#115](https://github.com/chef/vagrant-omnibus/pull/115) ([mbrukman](https://github.com/mbrukman))
+- Update README.md to point to current Travis location [\#101](https://github.com/chef/vagrant-omnibus/pull/101) ([petems](https://github.com/petems))
+- Change :latest to not hit rubygems [\#97](https://github.com/chef/vagrant-omnibus/pull/97) ([lamont-granquist](https://github.com/lamont-granquist))
+- README: added info about Windows support [\#94](https://github.com/chef/vagrant-omnibus/pull/94) ([docwhat](https://github.com/docwhat))
+- Fix string to use Ruby variables in tests [\#93](https://github.com/chef/vagrant-omnibus/pull/93) ([petems](https://github.com/petems))
+- Add plugin spec [\#92](https://github.com/chef/vagrant-omnibus/pull/92) ([petems](https://github.com/petems))
 
-- Issue [#79]: Install command not idempotent on Windows. ([@schisamo])
+## [v1.4.1](https://github.com/chef/vagrant-omnibus/tree/v1.4.1) (2014-04-26)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.4.0...v1.4.1)
 
-## 1.4.0 (April 25, 2014)
+## [v1.4.0](https://github.com/chef/vagrant-omnibus/tree/v1.4.0) (2014-04-25)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.3.1...v1.4.0)
 
-### New Features
+**Merged pull requests:**
 
-- PR [#73]: Full caching of omnibus package downloads! Huge thanks to [@tknerr] for all all his Herculean effort coordinating this fix in [vagrant-cachier/#13](https://github.com/fgrehm/vagrant-cachier/issues/13) and [opscode-omnitruck/#3](https://github.com/opscode/opscode-omnitruck/pull/33).
+- Cache omnibus download, expose config options [\#73](https://github.com/chef/vagrant-omnibus/pull/73) ([tknerr](https://github.com/tknerr))
+- Fix not specified chef version without internet connection [\#67](https://github.com/chef/vagrant-omnibus/pull/67) ([skv-headless](https://github.com/skv-headless))
 
-### Bug Fixes
+## [v1.3.1](https://github.com/chef/vagrant-omnibus/tree/v1.3.1) (2014-03-12)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.3.0...v1.3.1)
 
-- PR [#67]: No-op validation if `config.omnibus.chef_version` is `nil`. ([@skv-headless])
+**Merged pull requests:**
 
-## 1.3.1 (March 12, 2014)
+- run install.sh with `sh` rather than `bash`... [\#66](https://github.com/chef/vagrant-omnibus/pull/66) ([tknerr](https://github.com/tknerr))
+- make unlinking the install.sh reliably work on windows hosts [\#65](https://github.com/chef/vagrant-omnibus/pull/65) ([tknerr](https://github.com/tknerr))
 
-### Improvements
+## [v1.3.0](https://github.com/chef/vagrant-omnibus/tree/v1.3.0) (2014-02-24)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.2.1...v1.3.0)
 
-- PR [#66]: Run install.sh with `sh` rather than `bash`. ([@tknerr])
+**Merged pull requests:**
 
-### Bug Fixes
+- Make detection of currently installed Chef version more robust [\#61](https://github.com/chef/vagrant-omnibus/pull/61) ([ampedandwired](https://github.com/ampedandwired))
+- Windows Support Part Deux [\#60](https://github.com/chef/vagrant-omnibus/pull/60) ([schisamo](https://github.com/schisamo))
 
-- PR [#65]: Make unlinking the install.sh reliably work on windows hosts. ([@tknerr])
-- Issue [#69]: Ensure all remote commands are executed with `sh`. ([@schisamo])
+## [v1.2.1](https://github.com/chef/vagrant-omnibus/tree/v1.2.1) (2013-12-18)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.2.0...v1.2.1)
 
-## 1.3.0 (February 24, 2014)
+**Merged pull requests:**
 
-### New Features
+- filder 'stdin is not a tty' when trying to figure installed Chef version [\#57](https://github.com/chef/vagrant-omnibus/pull/57) ([scalp42](https://github.com/scalp42))
 
-- PR [#59], PR [#60]: Windows guest support! ([@jarig])([@schisamo])
+## [v1.2.0](https://github.com/chef/vagrant-omnibus/tree/v1.2.0) (2013-12-17)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.1.2...v1.2.0)
 
-### Improvements
+**Merged pull requests:**
 
-- PR [#61]: Make detection of currently installed Chef version more robust. ([@ampedandwired])
-- Create explicit tasks for supported provider acceptance tests. ([@schisamo])
-- Add Ruby 2.1.0 to the Travis CI test matrix. ([@schisamo])
+- Ruby linting with Rubocop [\#56](https://github.com/chef/vagrant-omnibus/pull/56) ([schisamo](https://github.com/schisamo))
+- Fix installed version check to be more robust [\#53](https://github.com/chef/vagrant-omnibus/pull/53) ([comutt](https://github.com/comutt))
+- Change plugin name to correspond gem name [\#52](https://github.com/chef/vagrant-omnibus/pull/52) ([tmatilai](https://github.com/tmatilai))
+- Update README.md with vagrant-parallels compatibility [\#50](https://github.com/chef/vagrant-omnibus/pull/50) ([wizonesolutions](https://github.com/wizonesolutions))
+- Don't install Chef if `--no-provision` is specified [\#48](https://github.com/chef/vagrant-omnibus/pull/48) ([tmatilai](https://github.com/tmatilai))
 
-### Bug Fixes
+## [v1.1.2](https://github.com/chef/vagrant-omnibus/tree/v1.1.2) (2013-10-17)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.1.1...v1.1.2)
 
-- Issue [#13]: Perform config validation at action execution time. ([@schisamo])
+**Merged pull requests:**
 
-## 1.2.1 (December 17, 2013)
+- Compatibility with vagrant-aws v0.4.0 [\#45](https://github.com/chef/vagrant-omnibus/pull/45) ([tmatilai](https://github.com/tmatilai))
+- Fix development dependencies and Travis tests [\#43](https://github.com/chef/vagrant-omnibus/pull/43) ([tmatilai](https://github.com/tmatilai))
+- Add vagrant-digitalocean to the list of supported providers [\#41](https://github.com/chef/vagrant-omnibus/pull/41) ([tmatilai](https://github.com/tmatilai))
 
-### Improvements
+## [v1.1.1](https://github.com/chef/vagrant-omnibus/tree/v1.1.1) (2013-09-04)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.1.0...v1.1.1)
 
-- Acceptance test coverage that verifies Chef is not reinstalled into a system where the desired version of Chef already exists. ([@schisamo])
+**Merged pull requests:**
 
-### Bug Fixes
+- Document that newer than v1.1.x Vagrant is fine, too [\#37](https://github.com/chef/vagrant-omnibus/pull/37) ([tmatilai](https://github.com/tmatilai))
+- Fix the curl line to install the requested Chef version [\#32](https://github.com/chef/vagrant-omnibus/pull/32) ([tmatilai](https://github.com/tmatilai))
+- no need to do sudo in sudo [\#31](https://github.com/chef/vagrant-omnibus/pull/31) ([matsu911](https://github.com/matsu911))
+- include OpenStack provider into the list of working providers [\#28](https://github.com/chef/vagrant-omnibus/pull/28) ([srenatus](https://github.com/srenatus))
 
-- PR [#57]: Filter `stdin is not a tty` when querying installed Chef version. ([@scalp42])
+## [v1.1.0](https://github.com/chef/vagrant-omnibus/tree/v1.1.0) (2013-06-21)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.0.2...v1.1.0)
 
-## 1.2.0 (December 17, 2013)
+**Merged pull requests:**
 
-### New Features
+- add support for vmware\_fusion [\#17](https://github.com/chef/vagrant-omnibus/pull/17) ([rjocoleman](https://github.com/rjocoleman))
 
-- PR [#52]: Change plugin name to correspond to gem name. ([@tmatilai])
+## [v1.0.2](https://github.com/chef/vagrant-omnibus/tree/v1.0.2) (2013-04-20)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.0.1...v1.0.2)
 
-### Improvements
+## [v1.0.1](https://github.com/chef/vagrant-omnibus/tree/v1.0.1) (2013-04-18)
+[Full Changelog](https://github.com/chef/vagrant-omnibus/compare/v1.0.0...v1.0.1)
 
-- PR [#48]: Don't install Chef if `--no-provision` is specified. ([@tmatilai])
-- PR [#50]: Update README.md with vagrant-parallels compatibility. ([@wizonesolutions])
-- PR [#56]: Add Rubocop support and fix style errors. ([@schisamo])
+## [v1.0.0](https://github.com/chef/vagrant-omnibus/tree/v1.0.0) (2013-04-02)
 
-### Bug Fixes
 
-- Issue [#12]: Ensure plugin is no-op on Windows guests. ([@schisamo])
-- PR [#53]: Ensure installed version check works on all platforms. ([@comutt])
-
-## 1.1.2 (October 17, 2013)
-
-### Improvements
-
-- PR [#41]: Add vagrant-digitalocean to the list of supported providers. ([@tmatilai])
-- PR [#45]: Compatibility with vagrant-aws v0.4.0 ([@tmatilai])
-- Use Vagrant's built in `Vagrant::Util::Downloader` class; removes requirement of the guest OS having `wget` or `curl` installed. ([@schisamo])
-
-### Bug Fixes
-
-- PR [#43]: Fix development dependencies and Travis tests. ([@tmatilai])
-- Issue [#33] Split fetching of `install.sh` from the actual execution ([@schisamo])
-
-## 1.1.1 (September 4, 2013)
-
-### Bug Fixes
-
-- PR [#28]: Include OpenStack provider into the list of working providers. ([@srenatus])
-- PR [#32], Issue [#31]: No need to do sudo in sudo ([@matsu911])
-- PR [#32], Issue [#32]: Fix the curl line to install the requested Chef version ([@tmatilai])
-- PR [#37]: Document that newer than v1.1.x Vagrant is fine, too. ([@tmatilai])
-- PR [#38]: Drop unneeded ConfigValidate action call ([@tmatilai])
-- Issue [#27]: Properly shell escape version strings ([@schisamo])
-
-## 1.1.0 (June 21, 2013)
-
-### New Features
-
-- PR [#23], Issue [#17], Issue [#19], Issue [#21], Issue [#23]: Support for all Vagrant providers that hook into `Vagrant::Action::Builtin::Provision` for provisioning. ([@smdahlen], [@michfield], [@rjocoleman])
-- Issue [#15]: Multi-VM Vagrantfiles are now fully supported. A global `omnibus.chef_version` will install the same version of Chef on all VMs OR declare a separate Chef version in the config block for each individual VM! ([@smdahlen], [@schisamo])
-- PR [#10]: Optionally change the location of `install.sh` via the `OMNIBUS_INSTALL_URL` environment variable. Default is still <https://www.opscode.com/chef/install.sh>. , ([@petecheslock])
-
-## 1.0.2 (April 20, 2013)
-
-### Improvements
-
-- Unit test coverage for `VagrantPlugins::Omnibus::Config` ([@schisamo])
-- Add Rackspace provider acceptance test. ([@schisamo])
-- Parameterize the acceptance test Rake task, this allows you test run acceptance tests against a single provider. ([@schisamo])
-
-### Bug Fixes
-
-- Issue [#2]: Convert `Gem::Version` returned by `#retrieve_latest_chef_version` to a string. ([@schisamo])
-- Issue [#6]: RubyGems 2.0 compat: use #empty? to check for results. ([@schisamo])
-- Issue [#7]: Ensure 'vagrant-rackspace/action' is loaded. ([@schisamo])
-- Issue [#8]: Trigger plugin if machine state is `:active`. ([@schisamo])
-
-## 1.0.1 (April 17, 2013)
-
-### Improvements
-
-- Issue [#2]: Resolve `latest` to a real Chef version. This ensures the plugin does not attempt to re-install Chef on subsequent provisions. ([@schisamo])
-- Issue [#4]: Validate user provided value for omnibus.chef_version is in fact a real Chef version. ([@schisamo])
-- Retrieve omnibus.chef_version directly from global config. ([@schisamo])
-- Update development dependencies to vagrant (1.2.1) and vagrant-aws (0.2.1). ([@schisamo])
-
-### Bug Fixes
-
-- Issue [#3]: Plugin now correctly operates in "no-op" node if now `omnibus.chef_version` is not present in the Vagrantfile. ([@schisamo])
-- Use Ubuntu 12.04 release AMI for acceptance testing. ([@schisamo])
-
-## 1.0.0 (April 1, 2013)
-
-- The initial release.
-
-<!-- - The following link definition list is generated by PimpMyChangelog - -->
-
-[#10]: https://github.com/schisamo/vagrant-omnibus/issues/10
-[#12]: https://github.com/schisamo/vagrant-omnibus/issues/12
-[#13]: https://github.com/schisamo/vagrant-omnibus/issues/13
-[#15]: https://github.com/schisamo/vagrant-omnibus/issues/15
-[#17]: https://github.com/schisamo/vagrant-omnibus/issues/17
-[#19]: https://github.com/schisamo/vagrant-omnibus/issues/19
-[#2]: https://github.com/schisamo/vagrant-omnibus/issues/2
-[#21]: https://github.com/schisamo/vagrant-omnibus/issues/21
-[#23]: https://github.com/schisamo/vagrant-omnibus/issues/23
-[#27]: https://github.com/schisamo/vagrant-omnibus/issues/27
-[#28]: https://github.com/schisamo/vagrant-omnibus/issues/28
-[#3]: https://github.com/schisamo/vagrant-omnibus/issues/3
-[#31]: https://github.com/schisamo/vagrant-omnibus/issues/31
-[#32]: https://github.com/schisamo/vagrant-omnibus/issues/32
-[#33]: https://github.com/schisamo/vagrant-omnibus/issues/33
-[#37]: https://github.com/schisamo/vagrant-omnibus/issues/37
-[#38]: https://github.com/schisamo/vagrant-omnibus/issues/38
-[#4]: https://github.com/schisamo/vagrant-omnibus/issues/4
-[#41]: https://github.com/schisamo/vagrant-omnibus/issues/41
-[#43]: https://github.com/schisamo/vagrant-omnibus/issues/43
-[#45]: https://github.com/schisamo/vagrant-omnibus/issues/45
-[#48]: https://github.com/schisamo/vagrant-omnibus/issues/48
-[#50]: https://github.com/schisamo/vagrant-omnibus/issues/50
-[#52]: https://github.com/schisamo/vagrant-omnibus/issues/52
-[#53]: https://github.com/schisamo/vagrant-omnibus/issues/53
-[#56]: https://github.com/schisamo/vagrant-omnibus/issues/56
-[#57]: https://github.com/schisamo/vagrant-omnibus/issues/57
-[#59]: https://github.com/schisamo/vagrant-omnibus/issues/59
-[#6]: https://github.com/schisamo/vagrant-omnibus/issues/6
-[#60]: https://github.com/schisamo/vagrant-omnibus/issues/60
-[#61]: https://github.com/schisamo/vagrant-omnibus/issues/61
-[#65]: https://github.com/schisamo/vagrant-omnibus/issues/65
-[#66]: https://github.com/schisamo/vagrant-omnibus/issues/66
-[#67]: https://github.com/schisamo/vagrant-omnibus/issues/67
-[#69]: https://github.com/schisamo/vagrant-omnibus/issues/69
-[#7]: https://github.com/schisamo/vagrant-omnibus/issues/7
-[#73]: https://github.com/schisamo/vagrant-omnibus/issues/73
-[#79]: https://github.com/schisamo/vagrant-omnibus/issues/79
-[#8]: https://github.com/schisamo/vagrant-omnibus/issues/8
-[@ampedandwired]: https://github.com/ampedandwired
-[@comutt]: https://github.com/comutt
-[@jarig]: https://github.com/jarig
-[@matsu911]: https://github.com/matsu911
-[@michfield]: https://github.com/michfield
-[@petecheslock]: https://github.com/petecheslock
-[@rjocoleman]: https://github.com/rjocoleman
-[@scalp42]: https://github.com/scalp42
-[@schisamo]: https://github.com/schisamo
-[@skv-headless]: https://github.com/skv-headless
-[@smdahlen]: https://github.com/smdahlen
-[@srenatus]: https://github.com/srenatus
-[@tknerr]: https://github.com/tknerr
-[@tmatilai]: https://github.com/tmatilai
-[@wizonesolutions]: https://github.com/wizonesolutions
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,8 @@ group :docs do
   gem "redcarpet", "~> 2.2"
   gem "github-markup", "~> 0.7"
 end
+
+group :changelog do
+  gem "github_changelog_generator"
+  gem "rack", "< 2" if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.2.2") # allows for Ruby 2.1.9 compatibility
+end

--- a/Rakefile
+++ b/Rakefile
@@ -83,5 +83,16 @@ namespace :travis do
   task ci: ["style:ruby", "test:unit"]
 end
 
+require "vagrant-omnibus/version"
+require "github_changelog_generator/task"
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.issues = false
+  config.future_release = VagrantPlugins::Omnibus::VERSION
+  config.enhancement_labels = "enhancement,Enhancement,New Feature".split(",")
+  config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
+  config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog".split(",")
+end
+
 # The default rake task should just run it all
 task default: ["style:ruby", "test:unit", "test:acceptance:virtualbox"]

--- a/lib/vagrant-omnibus/version.rb
+++ b/lib/vagrant-omnibus/version.rb
@@ -17,6 +17,6 @@
 module VagrantPlugins
   #
   module Omnibus
-    VERSION = "1.4.1"
+    VERSION = "1.5.0"
   end
 end

--- a/vagrant-omnibus.gemspec
+++ b/vagrant-omnibus.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "chefstyle", "~> 0.4.0"
+  spec.add_development_dependency "github_changelog_generator"
 end

--- a/vagrant-omnibus.gemspec
+++ b/vagrant-omnibus.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "chefstyle", "~> 0.4.0"
-  spec.add_development_dependency "github_changelog_generator"
 end


### PR DESCRIPTION
The changelog isn't nearly as nice, but we never need to worry about it
again. We don't get naming based on labels due to a bug in github
changelog generator.

Signed-off-by: Tim Smith <tsmith@chef.io>