### PR TITLE
update vagrant-linode versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :acceptance do
   gem "vagrant-digitalocean", "~> 0.5"
   gem "vagrant-aws", "~> 0.4"
   gem "vagrant-rackspace", "~> 0.1"
-  gem "vagrant-linode", "~> 0.2"
+  gem "vagrant-linode", "~> 0.4"
 end
 
 group :docs do

--- a/test/acceptance/linode/Vagrantfile
+++ b/test/acceptance/linode/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
     provider.token = ENV["LINODE_API_KEY"]
     provider.datacenter = "newark"
     provider.planid = 1
-    provider.distribution = "Ubuntu 14.04 LTS"
+    provider.distribution = "Ubuntu 18.04 LTS"
     override.ssh.private_key_path = "~/.ssh/id_rsa"
   end
 


### PR DESCRIPTION
#109 was updated in January 2015.  It was a few releases behind the latest vagrant-linode version.
Ubuntu 14.04 EOL's in less than 1 year.  Switch to Ubuntu 18.04 LTS for Linode acceptance testing.

- Update the version of vagrant-linode used
- Update the version of Ubuntu used in vagrant-linode acceptance tests